### PR TITLE
feat: add holiday list APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ import {
   getLastTradingDay,
   isHoliday,
   isTradingHoliday,
+  getHolidays,
+  getTradingHolidays,
+  getSupportedHolidayYears,
 } from "korea-business-day";
 
 // 영업일 확인
@@ -55,6 +58,8 @@ console.log(getNextBusinessDay("01/01/2025", { count: 1, format: "MM/dd/yyyy" })
 
 // 공휴일 확인
 console.log(isHoliday("2025-03-03")); // true (삼일절 대체휴일)
+console.log(getHolidays(2025)); // [{ date: "2025-01-01", name: "신정" }, ...]
+console.log(getSupportedHolidayYears()); // [2022, 2023, 2024, 2025, 2026, 2027]
 ```
 
 ## API 문서
@@ -225,9 +230,77 @@ console.log(isTradingHoliday("2025-01-02")); // false (정상 거래일)
 console.log(isTradingHoliday("12/31/2025", "MM/dd/yyyy")); // true (미국식 포맷)
 ```
 
+#### `getHolidays(year: number | string): Holiday[]`
+
+주어진 연도의 한국 공휴일 목록을 반환합니다. 지원하지 않는 연도는 빈 배열을 반환합니다.
+
+```typescript
+import { getHolidays } from "korea-business-day";
+
+console.log(getHolidays(2025));
+// [
+//   { date: "2025-01-01", name: "신정" },
+//   { date: "2025-01-27", name: "임시공휴일" },
+//   ...
+// ]
+
+console.log(getHolidays("2026"));
+// [{ date: "2026-01-01", name: "신정" }, ...]
+
+console.log(getHolidays(2021)); // []
+```
+
+#### `getTradingHolidays(year: number | string): TradingHoliday[]`
+
+주어진 연도의 한국 주식시장 휴무일 목록을 반환합니다. 일반 공휴일과 거래소 자체 휴장일을 포함하며, 지원하지 않는 연도는 빈 배열을 반환합니다.
+
+```typescript
+import { getTradingHolidays } from "korea-business-day";
+
+console.log(getTradingHolidays(2025));
+// [
+//   { date: "2025-01-01", name: "신정" },
+//   { date: "2025-01-27", name: "임시공휴일" },
+//   ...
+//   { date: "2025-12-31", name: "연말휴장일" }
+// ]
+
+console.log(getTradingHolidays("2026"));
+// [{ date: "2026-01-01", name: "신정" }, ...]
+
+console.log(getTradingHolidays(2021)); // []
+```
+
+#### `getSupportedHolidayYears(): number[]`
+
+공휴일 및 거래소 휴무일 데이터를 지원하는 연도 목록을 오름차순으로 반환합니다.
+
+```typescript
+import { getSupportedHolidayYears } from "korea-business-day";
+
+console.log(getSupportedHolidayYears());
+// [2022, 2023, 2024, 2025, 2026, 2027]
+```
+
+#### `Holiday`, `TradingHoliday`
+
+공휴일과 거래소 휴무일 목록 API는 날짜와 이름만 제공합니다. 휴일 유형은 제공하지 않습니다.
+
+```typescript
+type Holiday = {
+  date: string;
+  name: string;
+};
+
+type TradingHoliday = {
+  date: string;
+  name: string;
+};
+```
+
 ## 지원 연도
 
-현재 **2022년부터 2027년**까지의 휴일 데이터를 지원합니다.
+현재 **2022년부터 2027년**까지의 휴일 데이터를 지원합니다. 지원 연도는 `getSupportedHolidayYears()`로 확인할 수 있습니다.
 
 - 법정공휴일
 - 대체휴일

--- a/src/core/holiday.spec.ts
+++ b/src/core/holiday.spec.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { isHoliday, isTradingHoliday } from "./holiday.ts";
+import {
+  getHolidays,
+  getSupportedHolidayYears,
+  getTradingHolidays,
+  isHoliday,
+  isTradingHoliday,
+} from "./holiday.ts";
 
 describe("holiday", () => {
   describe("isHoliday", () => {
@@ -80,6 +86,116 @@ describe("holiday", () => {
     it("연말휴장일은 거래소 휴무일이지만 공휴일은 아님", () => {
       expect(isHoliday("2025-12-31")).toEqual(false); // 공휴일 아님
       expect(isTradingHoliday("2025-12-31")).toEqual(true); // 거래소 휴무일임
+    });
+  });
+
+  describe("getHolidays", () => {
+    it("지원하는 연도의 공휴일 목록을 날짜와 이름으로 반환해야 함", () => {
+      expect(getHolidays(2025)).toContainEqual({
+        date: "2025-01-01",
+        name: "신정",
+      });
+      expect(getHolidays(2025)).toContainEqual({
+        date: "2025-03-03",
+        name: "삼일절(대체휴일)",
+      });
+      expect(getHolidays(2025)).toContainEqual({
+        date: "2025-06-03",
+        name: "임시공휴일",
+      });
+      expect(getHolidays(2025)).not.toContainEqual({
+        date: "2025-12-31",
+        name: "연말휴장일",
+      });
+    });
+
+    it("문자열 연도 입력도 지원해야 함", () => {
+      expect(getHolidays("2026")).toContainEqual({
+        date: "2026-05-25",
+        name: "석가탄신일(대체휴일)",
+      });
+    });
+
+    it("지원하지 않는 연도에 대해서는 빈 배열을 반환해야 함", () => {
+      expect(getHolidays(2021)).toEqual([]);
+    });
+
+    it("반환한 배열과 객체를 수정해도 내부 데이터에 영향을 주지 않아야 함", () => {
+      const holidays = getHolidays(2025);
+      holidays.push({ date: "2025-01-02", name: "테스트 휴일" });
+      holidays[0].name = "수정된 이름";
+
+      expect(getHolidays(2025)).not.toContainEqual({
+        date: "2025-01-02",
+        name: "테스트 휴일",
+      });
+      expect(getHolidays(2025)[0].name).not.toEqual("수정된 이름");
+    });
+  });
+
+  describe("getTradingHolidays", () => {
+    it("지원하는 연도의 거래소 휴무일 목록을 날짜와 이름으로 반환해야 함", () => {
+      expect(getTradingHolidays(2025)).toContainEqual({
+        date: "2025-01-01",
+        name: "신정",
+      });
+      expect(getTradingHolidays(2025)).toContainEqual({
+        date: "2025-06-03",
+        name: "임시공휴일",
+      });
+      expect(getTradingHolidays(2025)).toContainEqual({
+        date: "2025-12-31",
+        name: "연말휴장일",
+      });
+    });
+
+    it("거래소 휴무일 목록은 일반 공휴일 목록을 포함해야 함", () => {
+      const holidays = getHolidays(2026);
+      const tradingHolidays = getTradingHolidays(2026);
+
+      holidays.forEach((holiday) => {
+        expect(tradingHolidays).toContainEqual(holiday);
+      });
+    });
+
+    it("문자열 연도 입력도 지원해야 함", () => {
+      expect(getTradingHolidays("2026")).toContainEqual({
+        date: "2026-12-31",
+        name: "연말휴장일",
+      });
+    });
+
+    it("지원하지 않는 연도에 대해서는 빈 배열을 반환해야 함", () => {
+      expect(getTradingHolidays(2021)).toEqual([]);
+    });
+
+    it("반환한 배열과 객체를 수정해도 내부 데이터에 영향을 주지 않아야 함", () => {
+      const tradingHolidays = getTradingHolidays(2025);
+      tradingHolidays.push({ date: "2025-01-02", name: "테스트 휴장일" });
+      tradingHolidays[0].name = "수정된 이름";
+
+      expect(getTradingHolidays(2025)).not.toContainEqual({
+        date: "2025-01-02",
+        name: "테스트 휴장일",
+      });
+      expect(getTradingHolidays(2025)[0].name).not.toEqual("수정된 이름");
+    });
+  });
+
+  describe("getSupportedHolidayYears", () => {
+    it("지원하는 공휴일 데이터 연도 목록을 오름차순으로 반환해야 함", () => {
+      expect(getSupportedHolidayYears()).toEqual([
+        2022, 2023, 2024, 2025, 2026, 2027,
+      ]);
+    });
+
+    it("반환한 배열을 수정해도 내부 데이터에 영향을 주지 않아야 함", () => {
+      const supportedYears = getSupportedHolidayYears();
+      supportedYears.push(2028);
+
+      expect(getSupportedHolidayYears()).toEqual([
+        2022, 2023, 2024, 2025, 2026, 2027,
+      ]);
     });
   });
 });

--- a/src/core/holiday.ts
+++ b/src/core/holiday.ts
@@ -1,5 +1,13 @@
-import { holidaysByYear, tradingHolidaysByYear } from "../holidays/index.ts";
+import {
+  holidayDetailsByYear,
+  holidaysByYear,
+  tradingHolidayDetailsByYear,
+  tradingHolidaysByYear,
+} from "../holidays/index.ts";
+import type { Holiday, TradingHoliday } from "../holidays/index.ts";
 import { parse, format } from "date-fns";
+
+export type { Holiday, TradingHoliday } from "../holidays/index.ts";
 
 /**
  * 주어진 날짜가 한국의 공휴일인지 판단합니다
@@ -39,4 +47,44 @@ export const isTradingHoliday = (
   const year = d.getFullYear().toString();
   const standardDate = format(d, "yyyy-MM-dd");
   return tradingHolidaysByYear[year]?.includes(standardDate) ?? false;
+};
+
+/**
+ * 주어진 연도의 한국 공휴일 목록을 반환합니다
+ * @param year - 확인할 연도
+ * @returns 공휴일 목록. 지원하지 않는 연도는 빈 배열을 반환합니다.
+ * @example
+ * getHolidays(2025); // [{ date: '2025-01-01', name: '신정' }, ...]
+ */
+export const getHolidays = (year: number | string): Holiday[] => {
+  return (holidayDetailsByYear[String(year)] ?? []).map((holiday) => ({
+    ...holiday,
+  }));
+};
+
+/**
+ * 주어진 연도의 한국 주식시장 휴무일 목록을 반환합니다
+ * @param year - 확인할 연도
+ * @returns 거래소 휴무일 목록. 지원하지 않는 연도는 빈 배열을 반환합니다.
+ * @example
+ * getTradingHolidays(2025); // [{ date: '2025-01-01', name: '신정' }, ...]
+ */
+export const getTradingHolidays = (
+  year: number | string
+): TradingHoliday[] => {
+  return (tradingHolidayDetailsByYear[String(year)] ?? []).map((holiday) => ({
+    ...holiday,
+  }));
+};
+
+/**
+ * 공휴일 및 거래소 휴무일 데이터를 지원하는 연도 목록을 반환합니다
+ * @returns 지원 연도 목록
+ * @example
+ * getSupportedHolidayYears(); // [2022, 2023, 2024, 2025, 2026, 2027]
+ */
+export const getSupportedHolidayYears = (): number[] => {
+  return Object.keys(holidayDetailsByYear)
+    .map(Number)
+    .sort((a, b) => a - b);
 };

--- a/src/holidays/2022.ts
+++ b/src/holidays/2022.ts
@@ -1,22 +1,31 @@
 
+import type { Holiday, TradingHoliday } from "./types.ts";
+
 // https://open.krx.co.kr/contents/MKD/01/0110/01100305/MKD01100305.jsp
-export const HOLIDAYS_2022: string[] = [
-  "2022-01-31", // 설날
-  "2022-02-01", // 설날
-  "2022-02-02", // 설날
-  "2022-03-01", // 삼일절
-  "2022-03-09", // 20대 대통령 선거
-  "2022-05-05", // 어린이날
-  "2022-06-01", // 8회 지방선거
-  "2022-06-06", // 현충일
-  "2022-08-15", // 광복절
-  "2022-09-09", // 추석
-  "2022-09-12", // 추석(대체휴일)
-  "2022-10-03", // 개천절
-  "2022-10-10", // 한글날(대체휴일)
+export const HOLIDAY_DETAILS_2022: Holiday[] = [
+  { date: "2022-01-31", name: "설날" },
+  { date: "2022-02-01", name: "설날" },
+  { date: "2022-02-02", name: "설날" },
+  { date: "2022-03-01", name: "삼일절" },
+  { date: "2022-03-09", name: "20대 대통령 선거" },
+  { date: "2022-05-05", name: "어린이날" },
+  { date: "2022-06-01", name: "8회 지방선거" },
+  { date: "2022-06-06", name: "현충일" },
+  { date: "2022-08-15", name: "광복절" },
+  { date: "2022-09-09", name: "추석" },
+  { date: "2022-09-12", name: "추석(대체휴일)" },
+  { date: "2022-10-03", name: "개천절" },
+  { date: "2022-10-10", name: "한글날(대체휴일)" },
 ];
 
-export const TRADING_HOLIDAYS_2022: string[] = [
-  ...HOLIDAYS_2022,
-  "2022-12-30", // 연말휴장일
+export const TRADING_HOLIDAY_DETAILS_2022: TradingHoliday[] = [
+  ...HOLIDAY_DETAILS_2022,
+  { date: "2022-12-30", name: "연말휴장일" },
 ];
+
+export const HOLIDAYS_2022: string[] = HOLIDAY_DETAILS_2022.map(
+  (holiday) => holiday.date
+);
+
+export const TRADING_HOLIDAYS_2022: string[] =
+  TRADING_HOLIDAY_DETAILS_2022.map((holiday) => holiday.date);

--- a/src/holidays/2023.ts
+++ b/src/holidays/2023.ts
@@ -1,23 +1,32 @@
 
+import type { Holiday, TradingHoliday } from "./types.ts";
+
 // https://open.krx.co.kr/contents/MKD/01/0110/01100305/MKD01100305.jsp
-export const HOLIDAYS_2023: string[] = [
-  "2023-01-23", // 설날
-  "2023-01-24", // 설날(대체휴일)
-  "2023-03-01", // 삼일절
-  "2023-05-01", // 근로자의날
-  "2023-05-05", // 어린이날
-  "2023-05-29", // 석가탄신일(대체휴일)
-  "2023-06-06", // 현충일
-  "2023-08-15", // 광복절
-  "2023-09-28", // 추석
-  "2023-09-29", // 추석
-  "2023-10-02", // 임시공휴일
-  "2023-10-03", // 개천절
-  "2023-10-09", // 한글날
-  "2023-12-25", // 성탄절
+export const HOLIDAY_DETAILS_2023: Holiday[] = [
+  { date: "2023-01-23", name: "설날" },
+  { date: "2023-01-24", name: "설날(대체휴일)" },
+  { date: "2023-03-01", name: "삼일절" },
+  { date: "2023-05-01", name: "근로자의날" },
+  { date: "2023-05-05", name: "어린이날" },
+  { date: "2023-05-29", name: "석가탄신일(대체휴일)" },
+  { date: "2023-06-06", name: "현충일" },
+  { date: "2023-08-15", name: "광복절" },
+  { date: "2023-09-28", name: "추석" },
+  { date: "2023-09-29", name: "추석" },
+  { date: "2023-10-02", name: "임시공휴일" },
+  { date: "2023-10-03", name: "개천절" },
+  { date: "2023-10-09", name: "한글날" },
+  { date: "2023-12-25", name: "성탄절" },
 ];
 
-export const TRADING_HOLIDAYS_2023: string[] = [
-  ...HOLIDAYS_2023,
-  "2023-12-29", // 연말휴장일
+export const TRADING_HOLIDAY_DETAILS_2023: TradingHoliday[] = [
+  ...HOLIDAY_DETAILS_2023,
+  { date: "2023-12-29", name: "연말휴장일" },
 ];
+
+export const HOLIDAYS_2023: string[] = HOLIDAY_DETAILS_2023.map(
+  (holiday) => holiday.date
+);
+
+export const TRADING_HOLIDAYS_2023: string[] =
+  TRADING_HOLIDAY_DETAILS_2023.map((holiday) => holiday.date);

--- a/src/holidays/2024.ts
+++ b/src/holidays/2024.ts
@@ -1,26 +1,35 @@
 
+import type { Holiday, TradingHoliday } from "./types.ts";
+
 // https://open.krx.co.kr/contents/MKD/01/0110/01100305/MKD01100305.jsp
-export const HOLIDAYS_2024: string[] = [
-  "2024-01-01", // 신정
-  "2024-02-09", // 설날
-  "2024-02-12", // 설날(대체휴일)
-  "2024-03-01", // 삼일절
-  "2024-04-10", // 임시공휴일
-  "2024-05-01", // 근로자의날
-  "2024-05-06", // 어린이날(대체휴일)
-  "2024-05-15", // 석가탄신일
-  "2024-06-06", // 현충일
-  "2024-08-15", // 광복절
-  "2024-09-16", // 추석
-  "2024-09-17", // 추석
-  "2024-09-18", // 추석
-  "2024-10-01", // 임시공휴일
-  "2024-10-03", // 개천절
-  "2024-10-09", // 한글날
-  "2024-12-25", // 성탄절
+export const HOLIDAY_DETAILS_2024: Holiday[] = [
+  { date: "2024-01-01", name: "신정" },
+  { date: "2024-02-09", name: "설날" },
+  { date: "2024-02-12", name: "설날(대체휴일)" },
+  { date: "2024-03-01", name: "삼일절" },
+  { date: "2024-04-10", name: "임시공휴일" },
+  { date: "2024-05-01", name: "근로자의날" },
+  { date: "2024-05-06", name: "어린이날(대체휴일)" },
+  { date: "2024-05-15", name: "석가탄신일" },
+  { date: "2024-06-06", name: "현충일" },
+  { date: "2024-08-15", name: "광복절" },
+  { date: "2024-09-16", name: "추석" },
+  { date: "2024-09-17", name: "추석" },
+  { date: "2024-09-18", name: "추석" },
+  { date: "2024-10-01", name: "임시공휴일" },
+  { date: "2024-10-03", name: "개천절" },
+  { date: "2024-10-09", name: "한글날" },
+  { date: "2024-12-25", name: "성탄절" },
 ];
 
-export const TRADING_HOLIDAYS_2024: string[] = [
-  ...HOLIDAYS_2024,
-  "2024-12-31", // 연말휴장일
+export const TRADING_HOLIDAY_DETAILS_2024: TradingHoliday[] = [
+  ...HOLIDAY_DETAILS_2024,
+  { date: "2024-12-31", name: "연말휴장일" },
 ];
+
+export const HOLIDAYS_2024: string[] = HOLIDAY_DETAILS_2024.map(
+  (holiday) => holiday.date
+);
+
+export const TRADING_HOLIDAYS_2024: string[] =
+  TRADING_HOLIDAY_DETAILS_2024.map((holiday) => holiday.date);

--- a/src/holidays/2025.ts
+++ b/src/holidays/2025.ts
@@ -1,27 +1,36 @@
 
+import type { Holiday, TradingHoliday } from "./types.ts";
+
 // https://open.krx.co.kr/contents/MKD/01/0110/01100305/MKD01100305.jsp
-export const HOLIDAYS_2025: string[] = [
-  "2025-01-01", // 신정
-  "2025-01-27", // 임시공휴일
-  "2025-01-28", // 설날
-  "2025-01-29", // 설날
-  "2025-01-30", // 설날
-  "2025-03-03", // 삼일절(대체휴일)
-  "2025-05-01", // 근로자의날
-  "2025-05-05", // 석가탄신일
-  "2025-05-06", // 어린이날(대체휴일)
-  "2025-06-03", // 임시공휴일
-  "2025-06-06", // 현충일
-  "2025-08-15", // 광복절
-  "2025-10-03", // 개천절
-  "2025-10-06", // 추석
-  "2025-10-07", // 추석
-  "2025-10-08", // 추석(대체휴일)
-  "2025-10-09", // 한글날
-  "2025-12-25", // 성탄절
+export const HOLIDAY_DETAILS_2025: Holiday[] = [
+  { date: "2025-01-01", name: "신정" },
+  { date: "2025-01-27", name: "임시공휴일" },
+  { date: "2025-01-28", name: "설날" },
+  { date: "2025-01-29", name: "설날" },
+  { date: "2025-01-30", name: "설날" },
+  { date: "2025-03-03", name: "삼일절(대체휴일)" },
+  { date: "2025-05-01", name: "근로자의날" },
+  { date: "2025-05-05", name: "석가탄신일" },
+  { date: "2025-05-06", name: "어린이날(대체휴일)" },
+  { date: "2025-06-03", name: "임시공휴일" },
+  { date: "2025-06-06", name: "현충일" },
+  { date: "2025-08-15", name: "광복절" },
+  { date: "2025-10-03", name: "개천절" },
+  { date: "2025-10-06", name: "추석" },
+  { date: "2025-10-07", name: "추석" },
+  { date: "2025-10-08", name: "추석(대체휴일)" },
+  { date: "2025-10-09", name: "한글날" },
+  { date: "2025-12-25", name: "성탄절" },
 ];
 
-export const TRADING_HOLIDAYS_2025: string[] = [
-  ...HOLIDAYS_2025,
-  "2025-12-31", // 연말휴장일
+export const TRADING_HOLIDAY_DETAILS_2025: TradingHoliday[] = [
+  ...HOLIDAY_DETAILS_2025,
+  { date: "2025-12-31", name: "연말휴장일" },
 ];
+
+export const HOLIDAYS_2025: string[] = HOLIDAY_DETAILS_2025.map(
+  (holiday) => holiday.date
+);
+
+export const TRADING_HOLIDAYS_2025: string[] =
+  TRADING_HOLIDAY_DETAILS_2025.map((holiday) => holiday.date);

--- a/src/holidays/2026.ts
+++ b/src/holidays/2026.ts
@@ -1,23 +1,32 @@
 
+import type { Holiday, TradingHoliday } from "./types.ts";
+
 // https://open.krx.co.kr/contents/MKD/01/0110/01100305/MKD01100305.jsp
-export const HOLIDAYS_2026: string[] = [
-  "2026-01-01", // 신정
-  "2026-02-16", // 설날
-  "2026-02-17", // 설날
-  "2026-02-18", // 설날
-  "2026-03-02", // 삼일절(대체휴일)
-  "2026-05-01", // 근로자의날
-  "2026-05-05", // 어린이날
-  "2026-05-25", // 석가탄신일(대체휴일)
-  "2026-08-17", // 광복절(대체휴일)
-  "2026-09-24", // 추석
-  "2026-09-25", // 추석
-  "2026-10-05", // 개천절(대체휴일)
-  "2026-10-09", // 한글날
-  "2026-12-25", // 성탄절
+export const HOLIDAY_DETAILS_2026: Holiday[] = [
+  { date: "2026-01-01", name: "신정" },
+  { date: "2026-02-16", name: "설날" },
+  { date: "2026-02-17", name: "설날" },
+  { date: "2026-02-18", name: "설날" },
+  { date: "2026-03-02", name: "삼일절(대체휴일)" },
+  { date: "2026-05-01", name: "근로자의날" },
+  { date: "2026-05-05", name: "어린이날" },
+  { date: "2026-05-25", name: "석가탄신일(대체휴일)" },
+  { date: "2026-08-17", name: "광복절(대체휴일)" },
+  { date: "2026-09-24", name: "추석" },
+  { date: "2026-09-25", name: "추석" },
+  { date: "2026-10-05", name: "개천절(대체휴일)" },
+  { date: "2026-10-09", name: "한글날" },
+  { date: "2026-12-25", name: "성탄절" },
 ];
 
-export const TRADING_HOLIDAYS_2026: string[] = [
-  ...HOLIDAYS_2026,
-  "2026-12-31", // 연말휴장일
+export const TRADING_HOLIDAY_DETAILS_2026: TradingHoliday[] = [
+  ...HOLIDAY_DETAILS_2026,
+  { date: "2026-12-31", name: "연말휴장일" },
 ];
+
+export const HOLIDAYS_2026: string[] = HOLIDAY_DETAILS_2026.map(
+  (holiday) => holiday.date
+);
+
+export const TRADING_HOLIDAYS_2026: string[] =
+  TRADING_HOLIDAY_DETAILS_2026.map((holiday) => holiday.date);

--- a/src/holidays/2027.ts
+++ b/src/holidays/2027.ts
@@ -1,22 +1,31 @@
 
+import type { Holiday, TradingHoliday } from "./types.ts";
+
 // https://open.krx.co.kr/contents/MKD/01/0110/01100305/MKD01100305.jsp
-export const HOLIDAYS_2027: string[] = [
-  "2027-01-01", // 신정
-  "2027-02-08", // 설날
-  "2027-02-09", // 설날(대체휴일)
-  "2027-03-01", // 삼일절
-  "2027-05-05", // 어린이날
-  "2027-05-13", // 석가탄신일
-  "2027-08-16", // 광복절(대체휴일)
-  "2027-09-14", // 추석
-  "2027-09-15", // 추석
-  "2027-09-16", // 추석
-  "2027-10-04", // 개천절(대체휴일)
-  "2027-10-11", // 한글날(대체휴일)
-  "2027-12-27", // 성탄절(대체휴일)
+export const HOLIDAY_DETAILS_2027: Holiday[] = [
+  { date: "2027-01-01", name: "신정" },
+  { date: "2027-02-08", name: "설날" },
+  { date: "2027-02-09", name: "설날(대체휴일)" },
+  { date: "2027-03-01", name: "삼일절" },
+  { date: "2027-05-05", name: "어린이날" },
+  { date: "2027-05-13", name: "석가탄신일" },
+  { date: "2027-08-16", name: "광복절(대체휴일)" },
+  { date: "2027-09-14", name: "추석" },
+  { date: "2027-09-15", name: "추석" },
+  { date: "2027-09-16", name: "추석" },
+  { date: "2027-10-04", name: "개천절(대체휴일)" },
+  { date: "2027-10-11", name: "한글날(대체휴일)" },
+  { date: "2027-12-27", name: "성탄절(대체휴일)" },
 ];
 
-export const TRADING_HOLIDAYS_2027: string[] = [
-  ...HOLIDAYS_2027,
-  "2027-12-31", // 연말휴장일
+export const TRADING_HOLIDAY_DETAILS_2027: TradingHoliday[] = [
+  ...HOLIDAY_DETAILS_2027,
+  { date: "2027-12-31", name: "연말휴장일" },
 ];
+
+export const HOLIDAYS_2027: string[] = HOLIDAY_DETAILS_2027.map(
+  (holiday) => holiday.date
+);
+
+export const TRADING_HOLIDAYS_2027: string[] =
+  TRADING_HOLIDAY_DETAILS_2027.map((holiday) => holiday.date);

--- a/src/holidays/index.ts
+++ b/src/holidays/index.ts
@@ -1,10 +1,43 @@
 
-import { HOLIDAYS_2022, TRADING_HOLIDAYS_2022 } from "./2022.ts";
-import { HOLIDAYS_2023, TRADING_HOLIDAYS_2023 } from "./2023.ts";
-import { HOLIDAYS_2024, TRADING_HOLIDAYS_2024 } from "./2024.ts";
-import { HOLIDAYS_2025, TRADING_HOLIDAYS_2025 } from "./2025.ts";
-import { HOLIDAYS_2026, TRADING_HOLIDAYS_2026 } from "./2026.ts";
-import { HOLIDAYS_2027, TRADING_HOLIDAYS_2027 } from "./2027.ts";
+import {
+  HOLIDAY_DETAILS_2022,
+  HOLIDAYS_2022,
+  TRADING_HOLIDAY_DETAILS_2022,
+  TRADING_HOLIDAYS_2022,
+} from "./2022.ts";
+import {
+  HOLIDAY_DETAILS_2023,
+  HOLIDAYS_2023,
+  TRADING_HOLIDAY_DETAILS_2023,
+  TRADING_HOLIDAYS_2023,
+} from "./2023.ts";
+import {
+  HOLIDAY_DETAILS_2024,
+  HOLIDAYS_2024,
+  TRADING_HOLIDAY_DETAILS_2024,
+  TRADING_HOLIDAYS_2024,
+} from "./2024.ts";
+import {
+  HOLIDAY_DETAILS_2025,
+  HOLIDAYS_2025,
+  TRADING_HOLIDAY_DETAILS_2025,
+  TRADING_HOLIDAYS_2025,
+} from "./2025.ts";
+import {
+  HOLIDAY_DETAILS_2026,
+  HOLIDAYS_2026,
+  TRADING_HOLIDAY_DETAILS_2026,
+  TRADING_HOLIDAYS_2026,
+} from "./2026.ts";
+import {
+  HOLIDAY_DETAILS_2027,
+  HOLIDAYS_2027,
+  TRADING_HOLIDAY_DETAILS_2027,
+  TRADING_HOLIDAYS_2027,
+} from "./2027.ts";
+import type { Holiday, TradingHoliday } from "./types.ts";
+
+export type { Holiday, TradingHoliday } from "./types.ts";
 
 export const holidaysByYear: Record<string, string[]> = {
   "2022": HOLIDAYS_2022,
@@ -22,4 +55,22 @@ export const tradingHolidaysByYear: Record<string, string[]> = {
   "2025": TRADING_HOLIDAYS_2025,
   "2026": TRADING_HOLIDAYS_2026,
   "2027": TRADING_HOLIDAYS_2027,
+};
+
+export const holidayDetailsByYear: Record<string, Holiday[]> = {
+  "2022": HOLIDAY_DETAILS_2022,
+  "2023": HOLIDAY_DETAILS_2023,
+  "2024": HOLIDAY_DETAILS_2024,
+  "2025": HOLIDAY_DETAILS_2025,
+  "2026": HOLIDAY_DETAILS_2026,
+  "2027": HOLIDAY_DETAILS_2027,
+};
+
+export const tradingHolidayDetailsByYear: Record<string, TradingHoliday[]> = {
+  "2022": TRADING_HOLIDAY_DETAILS_2022,
+  "2023": TRADING_HOLIDAY_DETAILS_2023,
+  "2024": TRADING_HOLIDAY_DETAILS_2024,
+  "2025": TRADING_HOLIDAY_DETAILS_2025,
+  "2026": TRADING_HOLIDAY_DETAILS_2026,
+  "2027": TRADING_HOLIDAY_DETAILS_2027,
 };

--- a/src/holidays/types.ts
+++ b/src/holidays/types.ts
@@ -1,0 +1,6 @@
+export type Holiday = {
+  date: string;
+  name: string;
+};
+
+export type TradingHoliday = Holiday;


### PR DESCRIPTION
## Summary

- add getHolidays, getTradingHolidays, and getSupportedHolidayYears APIs
- structure holiday data with date/name metadata while preserving existing date arrays
- document the new list APIs and supported year lookup

## Tests

- pnpm test -- --run
- pnpm typecheck
- pnpm lint

## Release

release: minor