### PR TITLE
ci: push release tags explicitly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,9 +184,10 @@ jobs:
           if git rev-parse "${VERSION}" >/dev/null 2>&1; then
             echo "Tag ${VERSION} already exists, skipping"
           else
-            git tag "${VERSION}"
+            git tag -a "${VERSION}" -m "${VERSION}"
           fi
-          git push --follow-tags
+          git push origin HEAD:${{ github.ref_name }}
+          git push origin "${VERSION}"
 
       - name: Create GitHub Release
         if: steps.release.outputs.has_changes == 'true'


### PR DESCRIPTION
## Summary

- create annotated release tags instead of lightweight tags
- push the release branch and tag explicitly so GitHub Release notes can be generated
- keep npm publish idempotent for already-published versions

## Tests

- git diff --check
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); puts 'yaml ok'"

## Release

release: none